### PR TITLE
Really ignore .pyc files, discuss virtual environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ capybara-*.html
 rerun.txt
 pickle-email-*.html
 .DS_Store
-.pyc
+*.pyc
+venv

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@ rerun.txt
 pickle-email-*.html
 .DS_Store
 *.pyc
-venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask==0.9
+Jinja2==2.6
+Werkzeug==0.8.3


### PR DESCRIPTION
I don't think `.pyc` files were ignored correctly on my system. Also, @mplewis, do you have Flask available globally on your system? I ran mine from a virtual environment named `venv` with virtualenv and `pip install`ed flask from there.

I'm assuming a lot of people will do that, and if people with graphical git use `venv` for their virtual environment then it won't be automatically added. :grin:
