### PR TITLE
Load projects

### DIFF
--- a/data/projects/audioproject.json
+++ b/data/projects/audioproject.json
@@ -8,11 +8,11 @@
         [
             "Volunteers to help teach analog theory",
             "Anyone who knows and can help teach PCB layout"
-        ]
+        ],
         "design":
         [
             "Anyone who wants to learn about designing for electronics"
-        ]
+        ],
         "marketing":
         [
             "Someone to contact UMN faculty about classroom integration"
@@ -25,15 +25,12 @@
             "email": "ken@condon.com",
             "phone": "612-555-1212"
         }
-    ]
-    "photos":
-    [
-        "frontpage": "img/audioproject/bigphoto.jpg",
-        "details":
-        [
-            "img/audioproject/photo1.jpg",
-            "img/audioproject/photo2.jpg",
-            "img/audioproject/photo3.jpg"
-        ]
     ],
+    "front_page_photo": "img/audioproject/bigphoto.jpg",
+    "detail_photos":
+    [
+        "img/audioproject/photo1.jpg",
+        "img/audioproject/photo2.jpg",
+        "img/audioproject/photo3.jpg"
+    ]
 }

--- a/data/projects/lightshow.json
+++ b/data/projects/lightshow.json
@@ -1,0 +1,37 @@
+{
+    "project_title": "CSE Light Show",
+    "project_goal": "Engineer and design a computer-synchronized music and light show on the Civil Engineering plaza.",
+    "project_details": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+    "project_needs":
+    {
+        "engineering":
+        [
+            "EE/CompEs to build the next-gen light control systems",
+            "People interested in writing apps for the Mac"
+        ],
+        "design":
+        [
+            "People who want to design the show's layout",
+            "Graphic designers for the posters"
+        ],
+        "marketing":
+        [
+            "Someone to plan the big kickoff event for 1,500 spectators!"
+        ]
+    },
+    "project_leaders":
+    [
+        {
+            "name": "Taylor Trimble",
+            "email": "taylortrimble@fake.com",
+            "phone": "612-555-2424"
+        }
+    ],
+    "front_page_photo": "img/lightshow/bigphoto.jpg",
+    "detail_photos":
+    [
+        "img/lightshow/photo1.jpg",
+        "img/lightshow/photo2.jpg",
+        "img/lightshow/photo3.jpg"
+    ]
+}

--- a/projects.py
+++ b/projects.py
@@ -1,9 +1,15 @@
 import json
+import os
 
-PROJECT_JSON_LOC = 'projects.json'
+PROJECT_JSON_LOC = 'data/projects'
 
 def get_projects():
-	with open(PROJECT_JSON_LOC, 'r') as f:
-		data = json.load(f)
-	project_list = data['projects']
-	return project_list
+    projects = {}
+    
+    for file_name in os.listdir(PROJECT_JSON_LOC):
+        long_file_name = os.path.join(PROJECT_JSON_LOC, file_name)
+        with open(long_file_name, 'r') as file:
+            data = json.load(file)
+        projects[file_name] = data
+    
+    return projects

--- a/projects.py
+++ b/projects.py
@@ -10,6 +10,8 @@ def get_projects():
         long_file_name = os.path.join(PROJECT_JSON_LOC, file_name)
         with open(long_file_name, 'r') as file:
             data = json.load(file)
-        projects[file_name] = data
+        
+        base_file_name = os.path.splitext(file_name)[0]
+        projects[base_file_name] = data
     
     return projects


### PR DESCRIPTION
Parses all `.json` project files in the `data/projects` directory and stores them in a projects dict. Dict key is base file name, and this is used for the project URL. Ex:

`audioproject.json` => `projects['audioproject']` => `teslaworks.net/audioproject`
`lightshow.json` => `projects['lightshow']` => `teslaworks.net/lightshow`

This will make it easy to test if a URL is valid!

Fixes #13.
