### PR TITLE
make <link>s absolute

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -9,9 +9,9 @@
     <meta name="author" content="">
 
     <!-- CSS -->
-    <link href="static/css/bootstrap.css" rel="stylesheet">
-    <link href="static/css/bootstrap-responsive.css" rel="stylesheet">
-    <link href="static/css/teslaworks.css" rel="stylesheet">
+    <link href="/static/css/bootstrap.css" rel="stylesheet">
+    <link href="/static/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="/static/css/teslaworks.css" rel="stylesheet">
 
     <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>


### PR DESCRIPTION
Closes #22 I think. Untested so far. Try it by going to `/somepage/somepage.html` that doesn't exist and see if the 404 page loses its styling.
