### PR TITLE
Titles, Templates, and Mastheads, Oh My!

### DIFF
--- a/static/css/bootstrap-mktg-narrow.css
+++ b/static/css/bootstrap-mktg-narrow.css
@@ -40,22 +40,3 @@ body {
     border: 1px solid #ccc;
     background-color: #eee;
 }
-
-/* Project leader stuff */
-.leader-name {
-    display: inline-block;
-    margin-top: 0;
-    margin-bottom: 0;
-    margin-right: 15px;
-}
-.leader-email, .leader-phone {
-    margin-right: 10px;
-}
-.leader-polaroid {
-    width: 140px;
-    height: 140px;
-    padding: 10px;
-    border-radius: 5px;
-    border: 1px solid #ccc;
-    background-color: #eee;
-}

--- a/static/css/teslaworks.css
+++ b/static/css/teslaworks.css
@@ -1,0 +1,19 @@
+/* Project leader stuff */
+
+.leader-name {
+    display: inline-block;
+    margin-top: 0;
+    margin-bottom: 0;
+    margin-right: 15px;
+}
+.leader-email, .leader-phone {
+    margin-right: 10px;
+}
+.leader-polaroid {
+    width: 140px;
+    height: 140px;
+    padding: 10px;
+    border-radius: 5px;
+    border: 1px solid #ccc;
+    background-color: #eee;
+}

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}404: Page Not Found{% endblock %}
+{% set title = '404' %}
 
 {% block html_body %}
 <div class="container">

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,6 +11,7 @@
     <!-- CSS -->
     <link href="/static/css/bootstrap.css" rel="stylesheet">
     <link href="/static/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="/static/css/bootstrap-mktg-narrow.css" rel="stylesheet">
     <link href="/static/css/teslaworks.css" rel="stylesheet">
 
     <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
@@ -23,9 +24,9 @@
 </head>
 
 <body>
-
-    {% block html_body %}{% endblock %}
-    {% block html_post_body %}{% endblock %}
-
+    <div class="container-narrow">
+        {% block html_body %}{% endblock %}
+        {% block html_post_body %}{% endblock %}
+    </div>
 </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     
     <meta charset="utf-8">
-    <title>{% block title %}{% endblock %} | Tesla Works</title>
+    <title>{{ title }} | Tesla Works</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="">
     <meta name="author" content="">
@@ -25,6 +25,7 @@
 
 <body>
     <div class="container-narrow">
+        {% include 'masthead.html' %}
         {% block html_body %}{% endblock %}
         {% block html_post_body %}{% endblock %}
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Home{% endblock %}
+{% set title = 'Home' %}
 
 {% block html_body %}
     <div class="container">

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,10 +3,10 @@
 {% set title = 'Home' %}
 
 {% block html_body %}
-    <div class="container">
+<div class="container">
 
-        <h1>Bootstrap starter template</h1>
-        <p>Use this document as a way to quick start any new project.<br> All you get is this message and a barebones HTML document.</p>
+    <h1>Bootstrap starter template</h1>
+    <p>Use this document as a way to quick start any new project.<br> All you get is this message and a barebones HTML document.</p>
 
-    </div>
+</div>
 {% endblock %}

--- a/templates/masthead.html
+++ b/templates/masthead.html
@@ -1,8 +1,11 @@
+<!-- This must be updated as more items are added to the masthead -->
+{% set default_masthead_items = ['Home', 'Blog'] %}
+
 <div class="masthead">
     <ul class="nav nav-pills pull-right">
-        <li{% if home %} class="active"{% endif %}><a href="/">Home</a></li>
-        {% if project_data %}<li class="active"><a href=".">{{ project_data.project_title }}</a></li>{% endif %}
-        <li{% if blog %} class="active"{% endif %}><a href="/blog">Blog</a></li>
+        <li{% if title == 'Home' %} class="active"{% endif %}><a href="/">Home</a></li>
+        {% if title is defined and title not in default_masthead_items %}<li class="active"><a href=".">{{ title }}</a></li>{% endif %}
+        <li{% if title == 'Blog' %} class="active"{% endif %}><a href="/blog">Blog</a></li>
     </ul>
     <h3><a href="/">Tesla Works</a></h3>
 </div>

--- a/templates/project.html
+++ b/templates/project.html
@@ -3,105 +3,98 @@
 {% block title %}{{ project_data.project_title }}{% endblock %}
 
 {% block html_head %}
-<link rel="stylesheet" href="/static/css/bootstrap-mktg-narrow.css">
 <link rel="stylesheet" href="/static/css/font-awesome.min.css">
 {% endblock %}
 
-{% block html_body %}
-
-<div class="container-narrow">
-
-    {% include "masthead.html" %}
-    
-    <div class="jumbotron">
-        <h1>{{ project_data.project_title }}</h1>
-        <div class="slideshow">
-        {% for img in project_data.photos.detail %}
-            <img class="big-polaroid" src="{{ img }}" alt="">
-        {% endfor %}
-        </div>
-        <p class="lead">{{ project_data.project_goal }}</p>
-        <a class="btn btn-large btn-success" href="#">Sign up today</a>
-    </div>
-
-    <hr>
-
-    <div class="row-fluid">
-        <h2>
-        {% if project_data.project_leaders|length > 1 %}
-            Project Leaders
-        {% else %}
-            Project Leader
-        {% endif %}
-        </h2>
-    </div>
-    
-    {% for leader in project_data.project_leaders %}
-    <div class="row-fluid">
-        <div class="span3">
-            <img src="{{ leader.photo }}" alt="" class="leader-polaroid">
-        </div>
-        <div class="span9">
-            <div class="row-fluid">
-                <h3 class="leader-name">{{  leader.name  }}</h3>
-                <a href="{{ leader.email }}" class="leader-email">{{ leader.email }}</a>
-                <span class="leader-phone">{{ leader.phone }}</span>
-            </div>
-            {{ leader.bio }}
-        </div>
-    </div>
+{% block html_body %}  
+  
+<div class="jumbotron">
+    <h1>{{ project_data.project_title }}</h1>
+    <div class="slideshow">
+    {% for img in project_data.photos.detail %}
+        <img class="big-polaroid" src="{{ img }}" alt="">
     {% endfor %}
-
-    <hr>
-    
-    <div class="row-fluid">
-        <h2>Project Needs</h2>
     </div>
-    <div class="row-fluid">
-        <div class="span6">
-            <h4><i class="icon-wrench"></i> Engineering</h4>
-            <ul>
-            {% for need in project_data.project_needs.engineering %}
-                <li>{{ need }}</li>
-            {% endfor %}
-            </ul>
-        </div>
-        <div class="span6">
-            <h4><i class="icon-edit"></i> Design</h4>
-            <ul>
-            {% for need in project_data.project_needs.design %}
-                <li>{{ need }}</li>
-            {% endfor %}
-            </ul>
-        </div>
+    <p class="lead">{{ project_data.project_goal }}</p>
+    <a class="btn btn-large btn-success" href="#">Sign up today</a>
+</div>
+
+<hr>
+
+<div class="row-fluid">
+    <h2>
+    {% if project_data.project_leaders|length > 1 %}
+        Project Leaders
+    {% else %}
+        Project Leader
+    {% endif %}
+    </h2>
+</div>
+
+{% for leader in project_data.project_leaders %}
+<div class="row-fluid">
+    <div class="span3">
+        <img src="{{ leader.photo }}" alt="" class="leader-polaroid">
     </div>
-    <div class="row-fluid">
-        <div class="span6">
-            <h4><i class="icon-shopping-cart"></i> Marketing</h4>
-            <ul>
-            {% for need in project_data.project_needs.marketing %}
-                <li>{{ need }}</li>
-            {% endfor %}
-            </ul>
+    <div class="span9">
+        <div class="row-fluid">
+            <h3 class="leader-name">{{  leader.name  }}</h3>
+            <a href="{{ leader.email }}" class="leader-email">{{ leader.email }}</a>
+            <span class="leader-phone">{{ leader.phone }}</span>
         </div>
-        <div class="span6">
-            <h4><i class="icon-beaker"></i> Other</h4>
-            <ul>
-            {% for need in project_data.project_needs.other %}
-                <li>{{ need }}</li>
-            {% endfor %}
-            </ul>
-
-        </div>
+        {{ leader.bio }}
     </div>
+</div>
+{% endfor %}
 
-    <hr>
+<hr>
 
-    <div class="footer">
-        <p>&copy; Tesla Works 2013</p>
+<div class="row-fluid">
+    <h2>Project Needs</h2>
+</div>
+<div class="row-fluid">
+    <div class="span6">
+        <h4><i class="icon-wrench"></i> Engineering</h4>
+        <ul>
+        {% for need in project_data.project_needs.engineering %}
+            <li>{{ need }}</li>
+        {% endfor %}
+        </ul>
     </div>
+    <div class="span6">
+        <h4><i class="icon-edit"></i> Design</h4>
+        <ul>
+        {% for need in project_data.project_needs.design %}
+            <li>{{ need }}</li>
+        {% endfor %}
+        </ul>
+    </div>
+</div>
+<div class="row-fluid">
+    <div class="span6">
+        <h4><i class="icon-shopping-cart"></i> Marketing</h4>
+        <ul>
+        {% for need in project_data.project_needs.marketing %}
+            <li>{{ need }}</li>
+        {% endfor %}
+        </ul>
+    </div>
+    <div class="span6">
+        <h4><i class="icon-beaker"></i> Other</h4>
+        <ul>
+        {% for need in project_data.project_needs.other %}
+            <li>{{ need }}</li>
+        {% endfor %}
+        </ul>
 
-</div> <!-- /container -->
+    </div>
+</div>
+
+<hr>
+
+<div class="footer">
+    <p>&copy; Tesla Works 2013</p>
+</div>
 
 {% endblock %}
 

--- a/templates/project.html
+++ b/templates/project.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ project_data.project_title }}{% endblock %}
+{% set title =  project_data.project_title %}
 
 {% block html_head %}
 <link rel="stylesheet" href="/static/css/font-awesome.min.css">


### PR DESCRIPTION
This is a moderate refactor with a BIG diff. Most of that is just indentation though, so here's what I did and why I did it:
### CSS Changes
1. Move the `bootstrap-mktg-narrow.css` to `base.html`. I like it so let's use it everywhere.
2. Move the project-leaders stuff out of `bootstrap-mktg-narrow.css` and into `teslaworks.css` to keep things updatable (in theory, we likely never will).

I though these were necessary for the architecture changes below, but they turned out not to be. So sorry, but this is a little bit of a piggy-back patch. Will undo if asked.
### Architecture Changes
1. Move the masthead to `base.html`. I like it so let's use it everywhere. Plus it helped make titling what it should be.
2. Titling, explained below.
##### Titling

I liked what you did with the project page's masthead. I took it one step further.

This is a clever idea I'm kind of proud of. Instead of using a block to provide a page's title, we'll use a Jinja2 variable. That variable is used to do a few things automatically for all pages:
1. The title is set for the page
2. If the title is "Home" or "Blog", the right nav pill is highlighted
3. If it's not "Home" or "Blog", a new nav pill is inserted between "Home" and "Blog" and is hightlighted.

The idea is that we won't want the Nav Pill to be different from the title anyway!

This gets slightly turned around when we get to blog posts... but that's another big idea I have to explain. For now, assume that all blog posts are titled "Blog".
