### PR TITLE
Yet another width setting system

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -1,10 +1,11 @@
 {% extends "base.html" %}
 
 {% set title = '404' %}
+{% set width = 8 %}
 
 {% block html_body %}
-<div class="container">
-	<h1>404</h1>
-	<p>Uh-oh! That page doesn't exist.</p>
-</div>
+
+<h1>404</h1>
+<p>Uh-oh! That page doesn't exist.</p>
+
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,20 +20,26 @@
 
 <body>
   <div class="container">
+
     <div class="row">
-      <div {% if page_width is defined %}class="{{ page_width }}"{% endif %}>
-        {% include 'masthead.html' %}
-      {% with messages = get_flashed_messages(with_categories=true) %}
-      {% if messages %}
-      {% for category, message in messages %}
-        <div class="alert alert-{{ category }} alert-dismissable">
-          <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-          {{ message }}
-        </div>
-      {% endfor %}
-      {% endif %}
-      {% endwith %}
-        {% block html_body %}{% endblock %}
+      <div class="col-md-offset-1 col-md-10">
+          {% include 'masthead.html' %}
+      </div>
+    </div>
+
+    <div class="row">
+      <div {% if width %}class="col-md-offset-{{ (12 - width) // 2 }} col-md-{{ width }}"{% endif %}>
+          {% with messages = get_flashed_messages(with_categories=true) %}
+          {% if messages %}
+          {% for category, message in messages %}
+          <div class="alert alert-{{ category }} alert-dismissable">
+            <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+            {{ message }}
+          </div>
+          {% endfor %}
+          {% endif %}
+          {% endwith %}
+          {% block html_body %}{% endblock %}
       </div>
     </div>
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% set title = 'Home' %}
-{% set page_width = 'col-md-offset-1 col-md-10' %}
+{% set width = 10 %}
 
 {% block html_head %}
 <link rel="stylesheet" href="/static/css/font-awesome.min.css">

--- a/templates/project.html
+++ b/templates/project.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% set title =  project_data.project_title %}
-{% set page_width = 'col-md-offset-2 col-md-8' %}
+{% set width = 8 %}
 
 {% block html_head %}
 <link rel="stylesheet" href="/static/css/font-awesome.min.css">

--- a/templates/start_project.html
+++ b/templates/start_project.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% set title = 'Start a Project' %}
-{% set page_width = 'col-md-offset-2 col-md-8' %}
+{% set width = 6 %}
 
 {% block html_body %}
 


### PR DESCRIPTION
I can't believe this worked! Here's the motivation:
- Our masthead jumping around **sucked**. I made it width 10. Now when
  we navigate between pages it's _awesome_. :tada: Takes some getting used to
  for us, but I think it's better.
- In templates, you set the width as an integer and the base template
  and some jinja math magic center it and stuff.
- More appropriate width on the start project page
