### PR TITLE
Use a single DB connection instead of opening one on each load

### DIFF
--- a/projects_controller.py
+++ b/projects_controller.py
@@ -27,14 +27,14 @@ class ProjectsController:
         return self
 
     def __exit__(self):
+        self.__exit__()
+
+    def close(self):
         try:
             if self.pg_conn:
                 self.pg_conn.close()
         except UnboundLocalError:
             pass
-
-    def close(self):
-        self.__exit__()
 
     def get_current_projects(self):
         if not self.got_past_projects:

--- a/projects_controller.py
+++ b/projects_controller.py
@@ -19,9 +19,9 @@ class ProjectsController:
         self.past_projects = None
         self.all_projects = None
         self.pg_conn = psycopg2.connect(host=config.DB_SETTINGS['HOST'],
-                                    database=config.DB_SETTINGS['DATABASE'],
-                                    user=config.DB_SETTINGS['USER'],
-                                    password=config.DB_SETTINGS['PASSWORD'])
+                                        database=config.DB_SETTINGS['DATABASE'],
+                                        user=config.DB_SETTINGS['USER'],
+                                        password=config.DB_SETTINGS['PASSWORD'])
 
     def __enter__(self):
         return self

--- a/server_dev.py
+++ b/server_dev.py
@@ -6,6 +6,7 @@ from redirects_controller import RedirectsController
 import config
 import re
 import strings
+import atexit
 
 app = Flask(__name__)
 app.secret_key = config.SECRET_KEY
@@ -18,6 +19,11 @@ mail = Mail(app)
 projects_controller = ProjectsController()
 redirects_controller = RedirectsController(config.DATA_DIR)
 
+def close_db_conn():
+    projects_controller.close()
+
+atexit.register(close_db_conn)
+
 _paragraph_re = re.compile(r'(?:\r\n|\r|\n){2,}')
 
 @app.template_filter()
@@ -28,7 +34,6 @@ def nl2br(eval_ctx, value):
     if eval_ctx.autoescape:
         result = Markup(result)
     return result
-
 
 @app.errorhandler(404)
 def page_not_found(e):
@@ -169,9 +174,7 @@ def redirect_url():
 def email_address(email):
     if app.debug or app.testing:
         return config.DEBUG_EMAIL
-    
     return email
-
 
 if __name__ == '__main__':
     app.run()


### PR DESCRIPTION
When `ProjectsController` is created, it opens a connection.

When it's closed, it closes that connection.

If we're feeling cool, we can use `with ProjectsController() as projects_controller`. But I don't think that works with Flask's layout and scoping.

We do have to register an `atexit` function to serve as a pseudo-`finally`.
